### PR TITLE
chore(htmlreporter): Print location of HTML report file when done

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,84 +1,84 @@
 {
-  "name": "stryker-html-reporter",
-  "version": "0.3.0",
-  "description": "An html reporter for the JavaScript mutation testing framework Stryker",
-  "main": "index.js",
-  "scripts": {
-    "test": "grunt test",
-    "preversion": "npm test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/stryker-mutator/stryker-html-reporter.git"
-  },
-  "keywords": [
-    "stryker",
-    "stryker-plugin",
-    "html",
-    "report",
-    "mutation",
-    "testing"
-  ],
-  "author": "Nico Jansen <nicoj@infosupport.com>",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/stryker-mutator/stryker-html-reporter/issues"
-  },
-  "homepage": "https://github.com/stryker-mutator/stryker-html-reporter#readme",
-  "dependencies": {
-    "handlebars": "^4.0.5",
-    "lodash": "^4.13.1",
-    "log4js": "^1.0.1",
-    "mkdirp": "^0.5.1",
-    "mz": "^2.5.0"
-  },
-  "peerDependencies": {
-    "stryker-api": "^0.4.0"
-  },
-  "devDependencies": {
-    "@types/chai": "^3.4.32",
-    "@types/chai-as-promised": "0.0.29",
-    "@types/handlebars": "^4.0.30",
-    "@types/lodash": "^4.14.34",
-    "@types/log4js": "0.0.31",
-    "@types/mkdirp": "^0.3.28",
-    "@types/mocha": "^2.2.31",
-    "@types/mz": "0.0.30",
-    "@types/node": "^6.0.38",
-    "@types/protractor": "^1.5.20",
-    "@types/selenium-webdriver": "2.44.*",
-    "@types/sinon": "^1.16.29",
-    "@types/sinon-chai": "^2.7.26",
-    "bootstrap": "3.3.7",
-    "chai": "^3.5.0",
-    "chai-as-promised": "^6.0.0",
-    "grunt": "^1.0.1",
-    "grunt-browserify": "^5.0.0",
-    "grunt-bump": "^0.8.0",
-    "grunt-cli": "^1.2.0",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-watch": "^1.0.0",
-    "grunt-conventional-changelog": "^6.1.0",
-    "grunt-mocha-istanbul": "^5.0.1",
-    "grunt-mocha-test": "^0.13.2",
-    "grunt-npm": "0.0.2",
-    "grunt-protractor-runner": "^4.0.0",
-    "grunt-ts": "^6.0.0-beta.3",
-    "grunt-tslint": "^3.2.1",
-    "highlight.js": "^9.4.0",
-    "istanbul": "^0.4.5",
-    "load-grunt-tasks": "^3.5.2",
-    "mocha": "^3.1.0",
-    "protractor": "^4.0.11",
-    "sinon": "^1.17.6",
-    "sinon-chai": "^2.8.0",
-    "stryker-api": "^0.4.1",
-    "tslint": "^3.15.1",
-    "typescript": "~2.0.10"
-  },
-  "contributors": [
-    "Nico Jansen <jansennico@gmail.com>",
-    "Simon de Lang <simondelang@gmail.com>"
-  ]
+    "name": "stryker-html-reporter",
+    "version": "0.3.0",
+    "description": "An html reporter for the JavaScript mutation testing framework Stryker",
+    "main": "index.js",
+    "scripts": {
+        "test": "grunt test",
+        "preversion": "npm test"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stryker-mutator/stryker-html-reporter.git"
+    },
+    "keywords": [
+        "stryker",
+        "stryker-plugin",
+        "html",
+        "report",
+        "mutation",
+        "testing"
+    ],
+    "author": "Nico Jansen <nicoj@infosupport.com>",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/stryker-mutator/stryker-html-reporter/issues"
+    },
+    "homepage": "https://github.com/stryker-mutator/stryker-html-reporter#readme",
+    "dependencies": {
+        "handlebars": "^4.0.5",
+        "lodash": "^4.13.1",
+        "log4js": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "mz": "^2.5.0"
+    },
+    "peerDependencies": {
+        "stryker-api": "^0.4.0"
+    },
+    "devDependencies": {
+        "@types/chai": "^3.4.32",
+        "@types/chai-as-promised": "0.0.29",
+        "@types/handlebars": "^4.0.30",
+        "@types/lodash": "^4.14.34",
+        "@types/log4js": "0.0.31",
+        "@types/mkdirp": "^0.3.28",
+        "@types/mocha": "^2.2.31",
+        "@types/mz": "0.0.30",
+        "@types/node": "^6.0.38",
+        "@types/protractor": "^1.5.20",
+        "@types/selenium-webdriver": "2.44.*",
+        "@types/sinon": "^1.16.29",
+        "@types/sinon-chai": "^2.7.26",
+        "bootstrap": "3.3.7",
+        "chai": "^3.5.0",
+        "chai-as-promised": "^6.0.0",
+        "grunt": "^1.0.1",
+        "grunt-browserify": "^5.0.0",
+        "grunt-bump": "^0.8.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-clean": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-watch": "^1.0.0",
+        "grunt-conventional-changelog": "^6.1.0",
+        "grunt-mocha-istanbul": "^5.0.1",
+        "grunt-mocha-test": "^0.13.2",
+        "grunt-npm": "0.0.2",
+        "grunt-protractor-runner": "^4.0.0",
+        "grunt-ts": "^6.0.0-beta.3",
+        "grunt-tslint": "^3.2.1",
+        "highlight.js": "^9.4.0",
+        "istanbul": "^0.4.5",
+        "load-grunt-tasks": "^3.5.2",
+        "mocha": "^3.1.0",
+        "protractor": "^4.0.11",
+        "sinon": "^1.17.6",
+        "sinon-chai": "^2.8.0",
+        "stryker-api": "^0.4.1",
+        "tslint": "^3.15.1",
+        "typescript": "~2.0.10"
+    },
+    "contributors": [
+        "Nico Jansen <jansennico@gmail.com>",
+        "Simon de Lang <simondelang@gmail.com>"
+    ]
 }

--- a/src/HtmlReporter.ts
+++ b/src/HtmlReporter.ts
@@ -55,6 +55,7 @@ export default class HtmlReporter implements Reporter {
   private writeReport() {
     this.rootNode.calculateModel('');
     this.rootNode.writeReportNodeRecursive(this.baseFolder);
+    log.info(`Your report can be found at: file:///${this.baseFolder}/index.html`);
   }
 
 

--- a/test/helpers/log4jsMock.ts
+++ b/test/helpers/log4jsMock.ts
@@ -1,7 +1,6 @@
 import * as log4js from 'log4js';
 import * as sinon from 'sinon';
 
-const l = log4js.getLogger();
 let logger = {
   isTraceEnabled: sinon.stub(),
   trace: sinon.stub(),

--- a/test/integration/HtmlReporterSpec.ts
+++ b/test/integration/HtmlReporterSpec.ts
@@ -1,7 +1,9 @@
 import HtmlReporter from '../../src/HtmlReporter';
 import * as fs from 'fs';
 import * as path from 'path';
-import {expect} from 'chai';
+import { expect } from 'chai';
+
+import logger from '../helpers/log4jsMock';
 
 const exampleMutations = require('./exampleMutations.json');
 const exampleSourceFiles = require('./exampleSourceFiles.json');
@@ -37,6 +39,10 @@ describe('HtmlReporter with example project', () => {
         expectFileExists(`${baseDir}/Add.js.html`, true);
       });
 
+      it('should output a log message with a link to the HTML report', () => {
+        expect(logger.info).to.have.been.calledWith(`Your report can be found at: file:///${baseDir}/index.html`);
+      });
+
     });
 
     describe('when initiated a second time with empty events', () => {
@@ -56,7 +62,5 @@ describe('HtmlReporter with example project', () => {
     });
 
   });
-
-
 });
 


### PR DESCRIPTION
See [Missing location to html files](https://github.com/stryker-mutator/stryker-html-reporter/issues/9)